### PR TITLE
Removes underline from normal links

### DIFF
--- a/_sass/overrides.scss
+++ b/_sass/overrides.scss
@@ -1,0 +1,12 @@
+a
+{
+    background-image: none !important;   
+}
+#markdown-toc a
+{
+    background-image: linear-gradient(#44434d 0%, #44434d 100%) !important;
+}
+.custom_toc a
+{
+    background-image: linear-gradient(#44434d 0%, #44434d 100%) !important;
+}


### PR DESCRIPTION
Hover functionality is unchanged from default "Just the Docs" (No hover)
TOC links remain unchanged, they have underline
Normal links > Removed underline

If you like the changes, approve pull request.
If you do not like the changes, close pr, no pressure.

Custom TOC's require {: custom_toc} at the bottom.

For example
`
## Guides
{: .no_toc .text-delta }
1. [Poking](https://epitaph.dev/docs/Tools/Assembly/Poking/)
{:.custom_toc}
`